### PR TITLE
README: drop -Dprefer_static=true builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,10 +139,3 @@ Compiling Instructions
 
     meson setup build
     meson compile -C build
-
-To ensure fast startup, ``platsch`` prefers using static libraries:
-
-.. code-block:: shell
-
-    meson setup -Dprefer_static=true build
-    meson compile -C build


### PR DESCRIPTION
Platsch always uses the static libraries (see meson.build).

Drop the deprecated static compilation comment here to not confuse the users.